### PR TITLE
Update with the ACE3's Scopes Framework

### DIFF
--- a/bwa3_comp_ace/CfgWeapons.hpp
+++ b/bwa3_comp_ace/CfgWeapons.hpp
@@ -28,6 +28,7 @@ class CfgWeapons {
     class BWA3_MP7: Pistol_Base_F {
         ACE_barrelTwist = 160.02;
         ACE_barrelLength = 180;
+        ACE_RailHeightAboveBore = 4.0;
     };
 
     class Rifle_Base_F;
@@ -39,6 +40,7 @@ class CfgWeapons {
         ACE_overheating_jamChance[] = {0, 0.0003, 0.0015, 0.0075};
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 480;
+        ACE_RailHeightAboveBore = 6.2;
 
         class AG40: UGL_F {
             magazines[] = {"1Rnd_HE_Grenade_shell","UGL_FlareWhite_F","UGL_FlareGreen_F","UGL_FlareRed_F","UGL_FlareYellow_F","UGL_FlareCIR_F","1Rnd_Smoke_Grenade_shell","1Rnd_SmokeRed_Grenade_shell","1Rnd_SmokeGreen_Grenade_shell","1Rnd_SmokeYellow_Grenade_shell","1Rnd_SmokePurple_Grenade_shell","1Rnd_SmokeBlue_Grenade_shell","1Rnd_SmokeOrange_Grenade_shell","3Rnd_HE_Grenade_shell","3Rnd_UGL_FlareWhite_F","3Rnd_UGL_FlareGreen_F","3Rnd_UGL_FlareRed_F","3Rnd_UGL_FlareYellow_F","3Rnd_UGL_FlareCIR_F","3Rnd_Smoke_Grenade_shell","3Rnd_SmokeRed_Grenade_shell","3Rnd_SmokeGreen_Grenade_shell","3Rnd_SmokeYellow_Grenade_shell","3Rnd_SmokePurple_Grenade_shell","3Rnd_SmokeBlue_Grenade_shell","3Rnd_SmokeOrange_Grenade_shell","ACE_HuntIR_M203"};
@@ -51,6 +53,27 @@ class CfgWeapons {
     class BWA3_G36_LMG: BWA3_G36 {
         ACE_overheating_dispersion[] = {0, 0.001, 0.002, 0.004};
     };
+    
+    class BWA3_G38: Rifle_Base_F {
+        ACE_overheating_dispersion[] = {0, 0.001, 0.003, 0.005};
+        ACE_overheating_slowdownFactor[] = {1, 1, 1, 0.9};
+        ACE_overheating_jamChance[] = {0, 0.0003, 0.0015, 0.0075};
+        ACE_barrelTwist = 177.8; // 1:7"
+        ACE_barrelLength = 419.1; // 16.5"
+        ACE_RailHeightAboveBore = 3.1;
+        
+        class AG40: UGL_F {
+            magazines[] = {"1Rnd_HE_Grenade_shell","UGL_FlareWhite_F","UGL_FlareGreen_F","UGL_FlareRed_F","UGL_FlareYellow_F","UGL_FlareCIR_F","1Rnd_Smoke_Grenade_shell","1Rnd_SmokeRed_Grenade_shell","1Rnd_SmokeGreen_Grenade_shell","1Rnd_SmokeYellow_Grenade_shell","1Rnd_SmokePurple_Grenade_shell","1Rnd_SmokeBlue_Grenade_shell","1Rnd_SmokeOrange_Grenade_shell","3Rnd_HE_Grenade_shell","3Rnd_UGL_FlareWhite_F","3Rnd_UGL_FlareGreen_F","3Rnd_UGL_FlareRed_F","3Rnd_UGL_FlareYellow_F","3Rnd_UGL_FlareCIR_F","3Rnd_Smoke_Grenade_shell","3Rnd_SmokeRed_Grenade_shell","3Rnd_SmokeGreen_Grenade_shell","3Rnd_SmokeYellow_Grenade_shell","3Rnd_SmokePurple_Grenade_shell","3Rnd_SmokeBlue_Grenade_shell","3Rnd_SmokeOrange_Grenade_shell","ACE_HuntIR_M203"};
+        };
+    };
+    class BWA3_G38K: BWA3_G38 {
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 368.3; // 14.5"
+    };
+    class BWA3_G38C: BWA3_G38 {
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 279.4; // 11"
+    };
 
     class Rifle_Long_Base_F;
     class BWA3_G28_Standard: Rifle_Long_Base_F {
@@ -60,6 +83,7 @@ class CfgWeapons {
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 421;
         ACE_gunbag_allowGunbag = 1;
+        ACE_RailHeightAboveBore = 3.6;
     };
     class BWA3_G28_Assault: BWA3_G28_Standard {
         ACE_barrelTwist = 304.8;
@@ -84,6 +108,7 @@ class CfgWeapons {
         ACE_overheating_jamChance[] = {0, 0.0003, 0.0015, 0.0075};
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 480;
+        ACE_RailHeightAboveBore = 4.0;
     };
 
     class BWA3_MG5: Rifle_Long_Base_F {
@@ -93,6 +118,7 @@ class CfgWeapons {
         ACE_overheating_jamChance[] = {0, 0.0003, 0.0015, 0.0075};
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 550;
+        ACE_RailHeightAboveBore = 3.6;
     };
 
     class BWA3_G82: Rifle_Long_Base_F {
@@ -102,6 +128,7 @@ class CfgWeapons {
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.7;
         ACE_gunbag_allowGunbag = 1;
+        ACE_RailHeightAboveBore = 3.8;
     };
 
     class Launcher;
@@ -217,12 +244,34 @@ class CfgWeapons {
 
     // OPTICS
     class InventoryOpticsItem_Base_F;
+    
+    class BWA3_optic_Kolimator_base: ItemCore {};
+    class BWA3_optic_RSAS: BWA3_optic_Kolimator_base {
+        ACE_ScopeHeightAboveRail = 2.6;
+    };
+    
+    class BWA3_optic_Flipsights: BWA3_optic_Kolimator_base {
+        ACE_ScopeHeightAboveRail = 1.5;
+    };
+    
+    class BWA3_optic_G36C_Ironsight_100: BWA3_optic_Kolimator_base {
+        ACE_ScopeHeightAboveRail = 1.5;
+    };
+    
+    class BWA3_optic_Aimpoint: BWA3_optic_Kolimator_base {
+        ACE_ScopeHeightAboveRail = 2.6;
+    };
+    
+    class BWA3_optic_EOTech: BWA3_optic_Kolimator_base {
+        ACE_ScopeHeightAboveRail = 4.1;
+    };
 
     class BWA3_optic_ZO4x30: ItemCore {
         ACE_scopeadjust_vertical[] = {-10, 10};
         ACE_scopeadjust_verticalIncrement = 0.2;
         ACE_scopeadjust_horizontal[] = {-10, 10};
         ACE_scopeadjust_horizontalIncrement = 0.2;
+        ACE_ScopeHeightAboveRail = 2.8;
 
         class ItemInfo : InventoryOpticsItem_Base_F {
             class OpticsModes {
@@ -239,6 +288,7 @@ class CfgWeapons {
         ACE_scopeadjust_verticalIncrement = 0.1;
         ACE_scopeadjust_horizontal[] = {-5.1, 5.1};
         ACE_scopeadjust_horizontalIncrement = 0.1;
+        ACE_ScopeHeightAboveRail = 4.0;
 
         class ItemInfo : InventoryOpticsItem_Base_F {
             class OpticsModes {
@@ -272,6 +322,7 @@ class CfgWeapons {
         ACE_scopeadjust_verticalIncrement = 0.1;
         ACE_scopeadjust_horizontal[] = {-7, 7};
         ACE_scopeadjust_horizontalIncrement = 0.1;
+        ACE_ScopeHeightAboveRail = 4.8;
 
         class ItemInfo : InventoryOpticsItem_Base_F {
             class OpticsModes {

--- a/bwa3_comp_ace/CfgWeapons.hpp
+++ b/bwa3_comp_ace/CfgWeapons.hpp
@@ -251,6 +251,7 @@ class CfgWeapons {
     };
 
     class BWA3_optic_20x50: ItemCore {
+        ACE_ScopeHeightAboveRail = 4.0;
         ACE_scopeadjust_vertical[] = {0, 26};
         ACE_scopeadjust_verticalIncrement = 0.1;
         ACE_scopeadjust_horizontal[] = {-6, 6};


### PR DESCRIPTION
- Add G38's variants.
- Update rifles, sniper rifles and MP7 with `ACE_RailHeightAboveBore`.
- Update scopes and sniper scopes with `ACE_ScopeHeightAboveRail`.

Reference from the R3F Mod: Bore Height=62mm with the PGM Poly scoped with the NXS 12-42x56. 